### PR TITLE
Update dependencies for security release, bump patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '10'
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prefixnote",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Annotate strings with simple, embedded prefix expressions.",
   "engines": {
     "node": ">=0.10.0"
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": "metaraine/prefixnote",
   "scripts": {
-    "test": "mocha --compilers js:babel/register"
+    "test": "mocha"
   },
   "keywords": [
     "string",
@@ -24,19 +24,18 @@
   "author": "Raine Lourie",
   "license": "ISC",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "chai": "^3.2.0",
-    "chai-as-promised": "^5.2.0",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "chai-things": "^0.2.0",
-    "mocha": "^2.3.0",
-    "stream-to-array": "^2.2.0"
+    "mocha": "^7.0.0",
+    "stream-to-array": "^2.3.0"
   },
   "dependencies": {
-    "bluebird": "^3.1.1",
-    "esprima": "^2.6.0",
+    "bluebird": "^3.7.2",
+    "esprima": "^4.0.1",
     "lodash.compact": "^3.0.0",
     "lodash.find": "^3.2.1",
     "regexp.execall": "^1.0.2",
-    "static-eval": "^0.2.4"
+    "static-eval": "^2.0.2"
   }
 }


### PR DESCRIPTION
I couldn't use prefixnote in a modern yeoman generator because of the older dependencies having critical security vulnerabilities (specifically static-eval).  I updated them, made sure tests still pass (they do not do well on Windows because of pathing I didn't figure out, but neither did the old ones).

Validated on node 10.18.1

Would it be possible to get this merged and pushed?  I'm willing to adjust things as well if need be.  Forewarning: I have little idea what I'm doing in Node land, but can throw myself at the wall enough times.