### PR TITLE
Update dependencies for security release, update tests, bump patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '10'
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prefixnote",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Annotate strings with simple, embedded prefix expressions.",
   "engines": {
     "node": ">=0.10.0"
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": "metaraine/prefixnote",
   "scripts": {
-    "test": "mocha --compilers js:babel/register"
+    "test": "mocha"
   },
   "keywords": [
     "string",
@@ -24,19 +24,18 @@
   "author": "Raine Lourie",
   "license": "ISC",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "chai": "^3.2.0",
-    "chai-as-promised": "^5.2.0",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "chai-things": "^0.2.0",
-    "mocha": "^2.3.0",
-    "stream-to-array": "^2.2.0"
+    "mocha": "^7.0.0",
+    "stream-to-array": "^2.3.0"
   },
   "dependencies": {
-    "bluebird": "^3.1.1",
-    "esprima": "^2.6.0",
+    "bluebird": "^3.7.2",
+    "esprima": "^4.0.1",
     "lodash.compact": "^3.0.0",
     "lodash.find": "^3.2.1",
     "regexp.execall": "^1.0.2",
-    "static-eval": "^0.2.4"
+    "static-eval": "^2.0.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
+const path = require('path')
 var chai = require('chai')
 var should = chai.should()
+var expect = chai.expect
 var prefixnote = require('../index.js')
 var toArray = require('stream-to-array')
 var Promise = require('bluebird')
@@ -206,99 +208,99 @@ describe('prefixnote', function() {
   describe('parseFiles', function() {
 
     it('should only parse files whose prefix evaluates to true', function() {
-      var parsedArray = toArray(prefixnote.parseFiles('test/sample', {
+      var parsedArray = toArray(prefixnote.parseFiles(path.join('test/sample'), {
         a: false,
         b: false
       }))
       return Promise.join(
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{}package.json',
-          parsed: 'test/sample/package.json',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{}package.json'),
+          parsed: path.join('test/sample/package.json'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/LICENSE',
-          parsed: 'test/sample/LICENSE',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/README.md'),
+          parsed: path.join('test/sample/README.md'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/README.md',
-          parsed: 'test/sample/README.md',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/LICENSE'),
+          parsed: path.join('test/sample/LICENSE'),
           parsedObject: { expression: null, args: [], options: {} }
         })
       )
     })
 
     it('should parse nested folders', function() {
-      var parsedArray = toArray(prefixnote.parseFiles('test/sample', {
+      var parsedArray = toArray(prefixnote.parseFiles(path.join('test/sample'), {
         a: true,
         a1: true,
         a2: false,
         b: false
       }))//.tap(console.log)
       return Promise.join(
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{}package.json',
-          parsed: 'test/sample/package.json',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{}package.json'),
+          parsed: path.join('test/sample/package.json'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/LICENSE',
-          parsed: 'test/sample/LICENSE',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/LICENSE'),
+          parsed: path.join('test/sample/LICENSE'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/README.md',
-          parsed: 'test/sample/README.md',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/README.md'),
+          parsed: path.join('test/sample/README.md'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{a}a/{a1}1',
-          parsed: 'test/sample/a/1',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{a}a/{a1}1'),
+          parsed: path.join('test/sample/a/1'),
           parsedObject: { expression: 'a1', args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{a}a/3',
-          parsed: 'test/sample/a/3',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{a}a/3'),
+          parsed: path.join('test/sample/a/3'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{a}a/4',
-          parsed: 'test/sample/a/4',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{a}a/4'),
+          parsed: path.join('test/sample/a/4'),
           parsedObject: { expression: null, args: [], options: {} }
         })
       )
     })
 
     it('should parse files in null folders as children of the parent', function() {
-      var parsedArray = toArray(prefixnote.parseFiles('test/sample', {
+      var parsedArray = toArray(prefixnote.parseFiles(path.join('test/sample'), {
         a: false,
         b: true
       }))
       return Promise.join(
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{}package.json',
-          parsed: 'test/sample/package.json',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{}package.json'),
+          parsed: path.join('test/sample/package.json'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/LICENSE',
-          parsed: 'test/sample/LICENSE',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/LICENSE'),
+          parsed: path.join('test/sample/LICENSE'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/README.md',
-          parsed: 'test/sample/README.md',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/README.md'),
+          parsed: path.join('test/sample/README.md'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{b}/1',
-          parsed: 'test/sample/1',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{b}/1'),
+          parsed: path.join('test/sample/1'),
           parsedObject: { expression: null, args: [], options: {} }
         }),
-        parsedArray.should.eventually.include({
-          original: 'test/sample/{b}/2',
-          parsed: 'test/sample/2',
+        parsedArray.should.eventually.deep.include({
+          original: path.join('test/sample/{b}/2'),
+          parsed: path.join('test/sample/2'),
           parsedObject: { expression: null, args: [], options: {} }
         })
       )


### PR DESCRIPTION
I couldn't use prefixnote in a modern yeoman generator because of the older dependencies having critical security vulnerabilities (specifically static-eval). I updated them, made sure tests still pass (they required updating for Windows pathing support and a newer version of mocha).

Validated on node 10.18.1

Would it be possible to get this merged and pushed? I'm willing to adjust things as well if need be. Forewarning: I have little idea what I'm doing in Node land, but can throw myself at the wall enough times.